### PR TITLE
Update README.md (wrong datatype initialization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Code Below
 
 Public Class Form1
     Dim result As String
-    Dim result1 As Str
-    Dim operate As Str
+    Dim result1 As String
+    Dim operate As String
 
     Private Sub Form1_Load(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles MyBase.Load
 


### PR DESCRIPTION
String in vb.net is declared as the following 

Dim num1 a String 

   And not as 

Dim num1 = Str